### PR TITLE
removing adClicks from coupon report

### DIFF
--- a/tap_google_analytics/defaults/default_report_definition.json
+++ b/tap_google_analytics/defaults/default_report_definition.json
@@ -526,7 +526,6 @@
     ],
     "metrics": [
       "ga:itemRevenue",
-      "ga:adClicks",
       "ga:transactions",
       "ga:transactionRevenue"
     ]


### PR DESCRIPTION
https://app.clickup.com/t/2575789/TECH-9058

Removing adClicks from coupon report as dimensions and metrics are configured to be automatically selected but this
could not be mixed with actual dimensions and metrics mentioned task.